### PR TITLE
Include a table of supported watch models

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -19,3 +19,24 @@ Do you want to install alternate firmware?
 Sensor Watch ships with a build of Movement that includes a Clock and World Clock, as well as a Sunrise/Sunset and Moon Phase complication (backer boards also include a Temperature watch face). If you wish to install an [alternate firmware](/docs/firmware/prebuilt/), you should download it and install it before installing your Sensor Watch board in the watch case, as installing it in the watch case renders the USB port inaccessible. Instructions for flashing new firmware [can be found here](/docs/firmware/flashing/).
 
 {{< youtube id="Zr0pKeC2VFU" >}}
+
+Compatible Models from Casio
+----------------------------
+The original F91W watch includes a case protecting a module.
+The Sensor Board is orinally made to fit into the [Module 593](https://en.wikipedia.org/wiki/Casio_F-91W) of the F-91W and is reported to work well with these models:
+
+| Model  | Comment                             |
+| ------ | ----------------------------------- |
+| F-84W  | Original Model, made in Japan       |
+| F-91W  | Made in China                       |
+| F-91WM | Metalic coloured case               |
+| F-91WS | Translucent coloured case           |
+| F-91WC | Neon Coloured case                  |
+| F-98W  |                                     |
+| A158   | Stainless steel case, Made in China |
+| A159   | Made in Japan                       |
+| A163   |                                     |
+| A164   |                                     |
+| A171   | Made in Thailand                    |
+
+Other models might also be working, but were not tested yet.


### PR DESCRIPTION
This is among the most ansked questions on the chat, so it is assumed useful to have this information at hand.

Across time, sensorwatch.net can become a reference gathering various efforts about the F-91W mods.