### PR TITLE
Fix consipicuous error ("Deutsche") in language selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 package-lock.json
 .hugo_build.lock
 .DS_Store
+.idea

--- a/config.toml
+++ b/config.toml
@@ -68,7 +68,7 @@ weight = 1
 [languages.de]
 title = "Sensor Watch"
 description = "A board swap for the classic Casio F-91W wristwatch"
-languageName ="Deutsche"
+languageName ="Deutsch"
 contentDir = "content/de"
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"


### PR DESCRIPTION
Correctly it is "Deutsch", without an -e