### PR TITLE
Added new watch W-59 & Dockerfile Instructions

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -37,6 +37,7 @@ Watches using this module include:
 | A164W | ✅     |              | A164WA (silver, black face) |
 | A171W | ✅     |              | A171WE (silver, black face), A171WEG (gold), A171WEGG (black), A171WEMG (gold) |
 | W-31  | ✅     |              | W-31 (vintage, stainless steel case & strap) |
+| W-59  | ✅     |              | W-59 (black) |
 | W-78  | ✅     |              | W-78 (vintage, larger and rounder with [a bit of a 90s look](http://whichwatchtoday.blogspot.com/2014/02/casio-w-78-alarm-chronograph.html)) |
 
 The 'Works' column indicates that someone has successfully transplanted the sensor watch module into that watch.

--- a/content/en/docs/movement/building.md
+++ b/content/en/docs/movement/building.md
@@ -37,6 +37,14 @@ Compile firmware
 
 The built firmware will be at `build/watch.uf2`. You can now [flash](/docs/firmware/flashing) this firmware to your watch.
 
+Docker
+----------------------------------------------
+* From within the [repo](https://github.com/joeycastillo/Sensor-Watch):
+* `docker build --build-arg USERID=$(id -u) -t sensorwatch .`
+* `docker run --rm -v $(pwd):/src -e COLOR=RED sensorwatch make` (for Sensor Watch Lite boards)
+
+The built firmware will be at `movement/make/build/watch.uf2`. You can now [flash](/docs/firmware/flashing) this firmware to your watch
+
 "I just want to pick my own set of watchfaces"
 ----------------------------------------------
 


### PR DESCRIPTION
I put the board into a Casio W-59. It works like it should. (see image) 

Additionally, I added documentation on how to use the Dockerfile from the following [this](https://github.com/joeycastillo/Sensor-Watch/pull/368) PR. 

![w59](https://github.com/joeycastillo/sensorwatch.net/assets/79413747/667ddbef-6853-48a7-985b-5a7de38113ef)