### PR TITLE
Bump Hugo from 0.123.0 to 0.123.8 (fix anchor-links)

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.0
+      HUGO_VERSION: 0.123.8
     steps:
       - name: Install Hugo CLI
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM klakegg/hugo:ext-alpine
-
-RUN apk add git && \
-  git config --global --add safe.directory /src

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,8 @@ version: "3.3"
 services:
 
   site:
-    image: docsy/docsy-example
-    build:
-      context: .
-    command: server
+    image: hugomods/hugo:go-git-0.123.8
+    command: hugo server --gc --minify --bind 0.0.0.0
     ports:
       - "1313:1313"
     volumes:


### PR DESCRIPTION
Issue:
At [this page](https://www.sensorwatch.net/docs/watchfaces/clock/), the links [at the top of the page](https://github.com/joeycastillo/sensorwatch.net/blob/cb40c10d4f3eb62f277d155a9bcf4af132978068/content/en/docs/watchfaces/clock.md?plain=1#L8-L17) are linking to baseURL `/#anchor` instead of linking to `/docs/watchfaces/clock/#anchor`.

Cause:
Hugo 0.123.0 introduces a bug that links anchor links to the base URL. This bug was fixed in [0.123.1](https://github.com/gohugoio/hugo/releases/tag/v0.123.1) with this change: https://github.com/gohugoio/hugo/issues/12084.

The change here contains the following:
- updates to the latest patch version of Hugo in 0.123.x which includes the fix for the bug above
- uses `hugomods/hugo` docker image to match the versions used for development and in the build pipeline for deployment