### PR TITLE
Additional supported model (W-59)

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -38,6 +38,7 @@ Watches using this module include:
 | A171W | ✅     |              | A171WE (silver, black face), A171WEG (gold), A171WEGG (black), A171WEMG (gold) |
 | W-31  | ✅     |              | W-31 (vintage, stainless steel case & strap) |
 | W-78  | ✅     |              | W-78 (vintage, larger and rounder with [a bit of a 90s look](http://whichwatchtoday.blogspot.com/2014/02/casio-w-78-alarm-chronograph.html)) |
+| W-59 | ✅     |              | W-59 (50 meters water resistant) with the 'Module 590' |
 
 The 'Works' column indicates that someone has successfully transplanted the sensor watch module into that watch.
 The 'Counterfeits' column means that someone has seen probable counterfeits for sale, so extra caution is warranted.


### PR DESCRIPTION
There is an additional model (W-59) that is very similar to the F-91W which I've confirmed supports the Sensor Watch board. It uses Module 590 which has the same size/layout/display of the 593.